### PR TITLE
Fix to try get working release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Install build requirements
@@ -34,7 +34,7 @@ jobs:
           python -c "import ansys.api.systemcoupling.v0; print('Sucessfully imported ansys.api.systemcoupling.v0')"
           python -c "from ansys.api.systemcoupling import __version__; print(__version__)"
       - name: Upload packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ansys-api-systemcoupling-packages
           path: dist/
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - uses: actions/download-artifact@v2
 


### PR DESCRIPTION
There was an error with Python version specification in `ci.yml`. Was expressed as number 3.10 rather than string "3.10" and therefore incorrectly interpreted as 3.1.  I had previously reverted upgrade of GitHub actions (originally upgraded to remove deprecation warnings) as I had misinterpreted the issue.